### PR TITLE
Text area fix

### DIFF
--- a/app/views/partials/input_textarea.scala.html
+++ b/app/views/partials/input_textarea.scala.html
@@ -45,7 +45,7 @@
         data-char-field
         cols="40"
         rows="5"
-        ></textarea>
+        >@field.value</textarea>
         @if(charLimit.isDefined){
             <noscript>
                 <p class="char-counter-text flush">@messages("site.textarea.char_limit", charLimit.get)</p>


### PR DESCRIPTION
## Issue was spotted by Rob Hawkes in the ddct-a11y channel on Slack.

**Original issue:**
If a user were to enter a description but NOT enter a name and/or email address (i.e. if the form had errors) then the 'value' would disappear.

**Solution:**
The value of the text area was being stored in a `value` attribute, therefore wasn't appearing when the form was submitted or page refresh.

Added the value inside the body of the element (I have left in the value attribute in case it is used by DeskPro.

This was the original issue:

![image](https://user-images.githubusercontent.com/53828896/66646744-f4b22380-ec1e-11e9-9bf2-c10e5231645a.png)
