### PR TITLE
PLATUI-512: Use referrerUrl if provided rather than the HTTP Referer header

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ standalone page. This parameter should contain the full, absolute, properly enco
 the contact form. For example, a link from the SCP sign in page would look like 
 `https://www.tax.service.gov.uk/contact/contact-hmrc-unauthenticated?service=scp&referrerUrl=https%3A%2F%2Fwww.access.service.gov.uk%2Flogin%2Fsignin%2Fcreds`
 
-The referer field is passed to the DeskPro service and lets operators know which page the user was on when they asked to
+The referrer field is passed to the DeskPro service and lets operators know which page the user was on when they asked to
 contact HMRC. If the referrerUrl is not supplied, the application will attempt to use the HTTP Header and userAction parameter (if present). 
 However, this mechanism is not recommended because it relies on browsers correctly forwarding the HTTP Referer header in all situations.
 
@@ -184,6 +184,7 @@ a) GET endpoint to show the form. This should result in making a backend GET cal
  * *service* - consuming services should specify their identifier as the 'service' parameter of requests to contact-frontend. The value of this parameter will later be passed to Splunk and would allow proper analysis of feedback
  * *canOmitComments* - consuming services can decide whether the 'comments' field is optional. To make it optional, the consuming service must add 'canOmitComments=true' field to the request
  * *csrfToken* - CSRF token generated from cookies of the consuming service. This parameter will be added automatically by the [play-partials](https://github.com/hmrc/play-partials) library and the service itself should't add it manually.
+ * *referrerUrl* - the full, absolute URL of the page the user is submitting feedback about.
 This endpoint will return a HTML partial than can then be embedded in the page layout.
 
 b) POST endpoint to submit the form. This should result in making a backend POST call to the endpoint
@@ -224,7 +225,7 @@ To display the standalone page, create a link from your accessibility statement 
 
 URL parameters:
 * *service* - consuming services should specify their identifier as the 'service' parameter of requests to contact-frontend. The value of this parameter will be later passed to Splunk and will allow you to properly analyze feedback
-* *userAction* - path of page the user reported in accessibility problem on. Since they arrive at the form from the accessibility statement page, we cannot rely on the referer header to track this, so we use this field to store the this value
+* *userAction* - path of page the user reported in accessibility problem on. Since they arrive at the form from the accessibility statement page, we cannot rely on the referrer header to track this, so we use this field to store the this value
 
 The form is intended to be displayed in a new tab or window. When the form is completed they are redirected to a confirmation page and prompted to close the tab or window.
 

--- a/app/controllers/AccessibilityController.scala
+++ b/app/controllers/AccessibilityController.scala
@@ -30,7 +30,7 @@ object AccessibilityFormBind {
   private val validateEmail: String => Boolean = emailValidator.validate
 
   def emptyForm(csrfToken: String,
-                referer: Option[String] = None,
+                referrer: Option[String] = None,
                 service: Option[String] = None,
                 userAction :Option[String] = None): Form[AccessibilityForm] = {
     AccessibilityFormBind.form.fill(
@@ -39,7 +39,7 @@ object AccessibilityFormBind {
         name = "",
         email = "",
         isJavascript = false,
-        referrer = referer.getOrElse("n/a"),
+        referrer = referrer.getOrElse("n/a"),
         csrfToken = csrfToken,
         service = service,
         userAction = userAction
@@ -58,7 +58,7 @@ object AccessibilityFormBind {
         .verifying("error.common.accessibility.problem.email_mandatory", validateEmail)
         .verifying("deskpro.email_too_long", email => email.length <= 255),
       "isJavascript" -> boolean,
-      "referer"      -> text,
+      "referrer"     -> text,
       "csrfToken"    -> text,
       "service"      -> optional(text),
       "userAction"   -> optional(text)
@@ -96,9 +96,9 @@ class AccessibilityController @Inject()(val hmrcDeskproConnector: HmrcDeskproCon
         authorised(AuthProviders(GovernmentGateway)) {
 
           Future.successful {
-            val referer   = request.headers.get("Referer")
+            val referrer  = request.headers.get(REFERER)
             val csrfToken = CSRF.getToken(request).map(_.value).getOrElse("")
-            val form      = AccessibilityFormBind.emptyForm(csrfToken, referer, service, userAction)
+            val form      = AccessibilityFormBind.emptyForm(csrfToken, referrer, service, userAction)
             Ok(accessibilityPage(form, routes.AccessibilityController.submitAccessibilityForm().url, loggedIn = true))
           }
 
@@ -139,9 +139,9 @@ class AccessibilityController @Inject()(val hmrcDeskproConnector: HmrcDeskproCon
 
   def unauthenticatedAccessibilityForm(service: Option[String], userAction: Option[String]): Action[AnyContent] = Action.async { implicit request =>
     Future.successful {
-      val referer   = request.headers.get("Referer")
+      val referrer  = request.headers.get(REFERER)
       val csrfToken = CSRF.getToken(request).map(_.value).getOrElse("")
-      val form      = AccessibilityFormBind.emptyForm(csrfToken, referer, service, userAction)
+      val form      = AccessibilityFormBind.emptyForm(csrfToken, referrer, service, userAction)
       Ok(accessibilityPage(form, routes.AccessibilityController.submitUnauthenticatedAccessibilityForm().url, loggedIn = false))
     }
   }

--- a/app/controllers/ContactHmrcController.scala
+++ b/app/controllers/ContactHmrcController.scala
@@ -22,6 +22,7 @@ import util.DeskproEmailValidator
 import views.html.helpers.recaptcha
 import views.html.partials.{contact_hmrc_form, contact_hmrc_form_confirmation}
 import views.html.{contact_hmrc, contact_hmrc_confirmation, deskpro_error}
+import play.api.http.HeaderNames._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -42,7 +43,7 @@ object ContactHmrcForm {
         .verifying("error.common.comments_mandatory", comment => !comment.trim.isEmpty)
         .verifying("error.common.comments_too_long", comment => comment.size <= 2000),
       "isJavascript" -> boolean,
-      "referer"      -> text,
+      "referrer"     -> text,
       "csrfToken"    -> text,
       "service"      -> optional(text),
       "abFeatures"   -> optional(text),
@@ -75,21 +76,21 @@ class ContactHmrcController @Inject()(val hmrcDeskproConnector: HmrcDeskproConne
   def index = Action.async { implicit request =>
     loginRedirection(routes.ContactHmrcController.index().url)(authorised(AuthProviders(GovernmentGateway))({
       Future.successful {
-        val referer   = request.headers.get("Referer").getOrElse("n/a")
+        val referrer  = request.headers.get(REFERER).getOrElse("n/a")
         val csrfToken = CSRF.getToken(request).map(_.value).getOrElse("")
-        Ok(contactPage(ContactHmrcForm.form.fill(ContactForm(referer, csrfToken, None, None, None)), loggedIn = true))
+        Ok(contactPage(ContactHmrcForm.form.fill(ContactForm(referrer, csrfToken, None, None, None)), loggedIn = true))
       }
     }))
   }
 
   def indexUnauthenticated(service: String, userAction: Option[String], referrerUrl: Option[String]) = Action.async { implicit request =>
     Future.successful {
-      val httpReferer = request.headers.get("Referer")
-      val referer = referrerUrl getOrElse (httpReferer getOrElse "n/a")
+      val httpReferrer = request.headers.get(REFERER)
+      val referrer = referrerUrl orElse httpReferrer getOrElse "n/a"
       val csrfToken = CSRF.getToken(request).map(_.value).getOrElse("")
       Ok(
         contactPage(
-          ContactHmrcForm.form.fill(ContactForm(referer, csrfToken, Some(service), None, userAction)),
+          ContactHmrcForm.form.fill(ContactForm(referrer, csrfToken, Some(service), None, userAction)),
           loggedIn = false,
           reCaptchaComponent = Some(recaptchaFormComponent("contact-hmrc")))
       )
@@ -154,7 +155,7 @@ class ContactHmrcController @Inject()(val hmrcDeskproConnector: HmrcDeskproConne
         Ok(
           contactHmrcForm(
             ContactHmrcForm.form.fill(
-              ContactForm(request.headers.get("Referer").getOrElse("n/a"), csrfToken, service, None, None)),
+              ContactForm(request.headers.get(REFERER).getOrElse("n/a"), csrfToken, service, None, None)),
             submitUrl,
             renderFormOnly))
       }
@@ -190,7 +191,7 @@ case class ContactForm(
   contactEmail: String,
   contactComments: String,
   isJavascript: Boolean,
-  referer: String,
+  referrer: String,
   csrfToken: String,
   service: Option[String]    = Some("unknown"),
   abFeatures: Option[String] = None,
@@ -198,10 +199,10 @@ case class ContactForm(
 )
 
 object ContactForm {
-  def apply(referer: String,
+  def apply(referrer: String,
             csrfToken: String,
             service: Option[String],
             abFeatures: Option[String],
             userAction: Option[String]): ContactForm =
-    ContactForm("", "", "", isJavascript = false, referer, csrfToken, service, abFeatures, userAction)
+    ContactForm("", "", "", isJavascript = false, referrer, csrfToken, service, abFeatures, userAction)
 }

--- a/app/controllers/ProblemReportsController.scala
+++ b/app/controllers/ProblemReportsController.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import util.{DeskproEmailValidator, GetHelpWithThisPageImprovedFieldValidation, GetHelpWithThisPageMoreVerboseConfirmation, GetHelpWithThisPageOnlyServerSideValidation}
 import views.html.partials.{error_feedback, error_feedback_inner}
 import views.html.{problem_reports_confirmation_nonjavascript, problem_reports_confirmation_nonjavascript_b, problem_reports_error_nonjavascript, problem_reports_nonjavascript, ticket_created_body, ticket_created_body_b}
-
+import play.api.http.HeaderNames._
 import scala.concurrent.{ExecutionContext, Future}
 
 object ProblemReportForm {
@@ -105,7 +105,7 @@ object ProblemReportForm {
         isJavascript = false,
         service      = service,
         abFeatures   = Some(appConfig.getFeatures(service).mkString(";")),
-        referrer     = request.headers.get("Referer"),
+        referrer     = request.headers.get(REFERER),
         userAction   = None
       )
     )
@@ -145,7 +145,7 @@ class ProblemReportsController @Inject()(val hmrcDeskproConnector: HmrcDeskproCo
 
   def reportFormAjax(service: Option[String]) = Action { implicit request =>
     val csrfToken = play.filters.csrf.CSRF.getToken(request).map(_.value)
-    val referrer  = request.headers.get("referer")
+    val referrer  = request.headers.get(REFERER)
     Ok(reportFormAjaxView(ProblemReportForm.emptyForm(service = service), service, csrfToken, referrer))
   }
 
@@ -157,7 +157,7 @@ class ProblemReportsController @Inject()(val hmrcDeskproConnector: HmrcDeskproCo
     errorFeedbackFormInner(form, appConfig.externalReportProblemSecureUrl, csrfToken, service, referrer)
 
   def reportFormNonJavaScript(service: Option[String]) = Action { implicit request =>
-    val referrer = request.headers.get("referer")
+    val referrer = request.headers.get(REFERER)
     Ok(
       problemReportsPage(
         ProblemReportForm.emptyForm(service = service),
@@ -174,7 +174,7 @@ class ProblemReportsController @Inject()(val hmrcDeskproConnector: HmrcDeskproCo
     ProblemReportForm.form.bindFromRequest.fold(
       (error: Form[ProblemReport]) => {
 
-        val referrer = error.data.get("referrer").filter(_.trim.nonEmpty).orElse(request.headers.get("referer"))
+        val referrer = error.data.get("referrer").filter(_.trim.nonEmpty).orElse(request.headers.get(REFERER))
 
         if (isAjax) {
           if (appConfig.hasFeature(GetHelpWithThisPageOnlyServerSideValidation, error.data.get("service"))) {
@@ -199,7 +199,7 @@ class ProblemReportsController @Inject()(val hmrcDeskproConnector: HmrcDeskproCo
       },
       problemReport => {
 
-        val referrer = problemReport.referrer.filter(_.trim.nonEmpty).orElse(request.headers.get("referer"))
+        val referrer = problemReport.referrer.filter(_.trim.nonEmpty).orElse(request.headers.get(REFERER))
 
         (for {
           maybeUserEnrolments <- maybeAuthenticatedUserEnrolments

--- a/app/model/package.scala
+++ b/app/model/package.scala
@@ -40,14 +40,14 @@ case class FeedbackForm(
   canOmitComments: Boolean)
 
 object FeedbackForm {
-  def apply(referer: String, csrfToken: String, backUrl: Option[String], canOmitComments: Boolean): FeedbackForm =
+  def apply(referrer: String, csrfToken: String, backUrl: Option[String], canOmitComments: Boolean): FeedbackForm =
     FeedbackForm(
       "",
       "",
       "",
       "",
       javascriptEnabled = false,
-      referrer          = referer,
+      referrer          = referrer,
       csrfToken         = csrfToken,
       backUrl           = backUrl,
       canOmitComments   = canOmitComments)

--- a/app/services/DeskproSubmission.scala
+++ b/app/services/DeskproSubmission.scala
@@ -21,7 +21,7 @@ import scala.util.Try
 
 trait DeskproSubmission {
 
-  import DeskproSubmission.replaceRefererPath
+  import DeskproSubmission.replaceReferrerPath
 
   private val Subject = "Contact form submission"
 
@@ -35,7 +35,7 @@ trait DeskproSubmission {
       email            = data.contactEmail,
       subject          = Subject,
       message          = data.contactComments,
-      referrer         = replaceRefererPath(data.referer, data.userAction),
+      referrer         = replaceReferrerPath(data.referrer, data.userAction),
       isJavascript     = data.isJavascript,
       request          = request,
       enrolmentsOption = enrolments,
@@ -75,7 +75,7 @@ trait DeskproSubmission {
       email            = problemReport.reportEmail,
       subject          = "Support Request",
       message          = problemMessage(problemReport.reportAction, problemReport.reportError),
-      referrer         = replaceRefererPath(referrer.getOrElse(""), problemReport.userAction),
+      referrer         = replaceReferrerPath(referrer.getOrElse(""), problemReport.userAction),
       isJavascript     = problemReport.isJavascript,
       request          = request,
       enrolmentsOption = enrolmentsOption,
@@ -101,7 +101,7 @@ trait DeskproSubmission {
       email            = accessibilityForm.email,
       subject          = "Accessibility Problem",
       message          = accessibilityForm.problemDescription,
-      referrer         = replaceRefererPath(accessibilityForm.referrer, accessibilityForm.userAction),
+      referrer         = replaceReferrerPath(accessibilityForm.referrer, accessibilityForm.userAction),
       isJavascript     = accessibilityForm.isJavascript,
       request          = req,
       enrolmentsOption = enrolments,
@@ -115,14 +115,14 @@ trait DeskproSubmission {
 
 object DeskproSubmission {
 
-    def replaceRefererPath(referer: String, path: Option[String]): String =
+    def replaceReferrerPath(referrer: String, path: Option[String]): String =
       path
         .filter(_.trim.nonEmpty)
-        .map(p => buildUri(referer).setPath(p).build().toASCIIString)
-        .getOrElse(referer)
+        .map(p => buildUri(referrer).setPath(p).build().toASCIIString)
+        .getOrElse(referrer)
 
-  private def buildUri(referer: String) : URIBuilder =
-    Try(new URIBuilder(referer)).getOrElse(new URIBuilder())
+  private def buildUri(referrer: String) : URIBuilder =
+    Try(new URIBuilder(referrer)).getOrElse(new URIBuilder())
 
 
 }

--- a/app/views/partials/accessibility_form.scala.html
+++ b/app/views/partials/accessibility_form.scala.html
@@ -66,7 +66,7 @@
     )
 
     <input type="hidden" name="isJavascript" id="isJavascript" value="@accessibilityForm("isJavascript").value">
-    <input type="hidden" name="referer" id="referer" value="@accessibilityForm("referer").value">
+    <input type="hidden" name="referrer" id="referrer" value="@accessibilityForm("referrer").value">
     <input type="hidden" name="userAction" id="userAction" value="@accessibilityForm("userAction").value">
 
     <div class="form-field">

--- a/app/views/partials/contact_hmrc_form.scala.html
+++ b/app/views/partials/contact_hmrc_form.scala.html
@@ -50,7 +50,7 @@
         )
 
         <input type="hidden" name="isJavascript" id="isJavascript" value="@contactForm.data.get("isJavascript")">
-        <input type="hidden" name="referer" id="referer" value="@contactForm.data.get("referer")">
+        <input type="hidden" name="referrer" id="referrer" value="@contactForm.data.get("referrer")">
         <input type="hidden" name="userAction" id="userAction" value="@contactForm("userAction").value" />
 
         @reCaptchaComponent.map { component => @component }

--- a/app/views/partials/feedback_form.scala.html
+++ b/app/views/partials/feedback_form.scala.html
@@ -60,7 +60,7 @@
         )
 
         <input type="hidden" name="isJavascript" id="isJavascript" value="@feedbackForm.data.get("isJavascript")">
-        <input type="hidden" name="referer" id="referer" value="@feedbackForm.data.get("referer")">
+        <input type="hidden" name="referrer" id="referrer" value="@feedbackForm.data.get("referrer")">
         <input type="hidden" name="canOmitComments" id="canOmitComments" value="@canOmitComments">
         @for(url <- backUrl) {
             <input type="hidden" name="backUrl" id="feedbackBackUrl" value="@url">

--- a/conf/contact.routes
+++ b/conf/contact.routes
@@ -5,7 +5,7 @@ POST        /beta-feedback/submit-unauthenticated        @controllers.FeedbackCo
 GET         /beta-feedback/thanks                        @controllers.FeedbackController.thanks(backUrl: Option[String])
 GET         /beta-feedback/thanks-unauthenticated        @controllers.FeedbackController.unauthenticatedThanks(backUrl: Option[String])
 
-GET         /beta-feedback/form                          @controllers.FeedbackController.feedbackPartialForm(submitUrl: String, csrfToken: String, service: Option[String], referer: Option[String], canOmitComments: Boolean ?= false)
+GET         /beta-feedback/form                          @controllers.FeedbackController.feedbackPartialForm(submitUrl: String, csrfToken: String, service: Option[String], referer: Option[String], canOmitComments: Boolean ?= false, referrerUrl: Option[String])
 POST        /beta-feedback/form                          @controllers.FeedbackController.submitFeedbackPartialForm(resubmitUrl: String)
 GET         /beta-feedback/form/confirmation             @controllers.FeedbackController.feedbackPartialFormConfirmation(ticketId: String)
 

--- a/test/connectors/deskpro/domain/FieldTransformerSpec.scala
+++ b/test/connectors/deskpro/domain/FieldTransformerSpec.scala
@@ -126,7 +126,7 @@ class FieldTransformerScope {
   val email: String = "email"
   val subject: String = "subject"
   val message: String = "message"
-  val referrer: String = "referer"
+  val referrer: String = "referrer"
   lazy val request = FakeRequest().withHeaders(("User-Agent", userAgent))
   lazy val requestAuthenticatedByIda = FakeRequest().withHeaders(("User-Agent", userAgent)).withSession((SessionKeys.authProvider, "IDA"))
 

--- a/test/controllers/AccessibilityControllerSpec.scala
+++ b/test/controllers/AccessibilityControllerSpec.scala
@@ -346,12 +346,12 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
         "csrfToken" -> "token",
         "isJavascript" -> isJavascript.toString,
         "csrfToken" -> "a-csrf-token",
-        "referer" -> referrer,
+        "referrer" -> referrer,
         "service" -> "unit-test",
         "userAction" -> "/test/url/action")
 
       FakeRequest()
-        .withHeaders(("referer", referrer))
+        .withHeaders((REFERER, referrer))
         .withFormUrlEncodedBody(fields.toSeq: _*)
     }
   }

--- a/test/controllers/ContactHmrcControllerSpec.scala
+++ b/test/controllers/ContactHmrcControllerSpec.scala
@@ -57,7 +57,7 @@ class ContactHmrcControllerSpec
       Given("a GET request")
       mockDeskproConnector(Future.successful(TicketId(12345)))
 
-      val contactRequest = FakeRequest().withHeaders(("Referer", "/some-service-page"))
+      val contactRequest = FakeRequest().withHeaders((REFERER, "/some-service-page"))
       val serviceName = "my-fake-service"
 
       When("the unauthenticated Contact HMRC page is requested with a service name")
@@ -67,7 +67,7 @@ class ContactHmrcControllerSpec
       status(contactResult) shouldBe 200
 
       val page = Jsoup.parse(contentAsString(contactResult))
-      page.body().getElementById("referer").attr("value") shouldBe "/some-service-page"
+      page.body().getElementById("referrer").attr("value") shouldBe "/some-service-page"
       page.body().getElementById("service").attr("value") shouldBe "my-fake-service"
     }
 
@@ -75,19 +75,19 @@ class ContactHmrcControllerSpec
       Given("a GET request")
       mockDeskproConnector(Future.successful(TicketId(12345)))
 
-      val contactRequest = FakeRequest().withHeaders(("Referer", "/some-service-page"))
+      val contactRequest = FakeRequest().withHeaders((REFERER, "/some-service-page"))
       val serviceName = "my-fake-service"
       val referrerUrl = Some("https://www.example.com/some-service")
 
-      When("the unauthenticated Contact HMRC page is requested with a service name and a referer url")
+      When("the unauthenticated Contact HMRC page is requested with a service name and a referrer url")
       val contactResult = controller.indexUnauthenticated(serviceName, None, referrerUrl)(contactRequest)
 
-      Then("the referer hidden input should contain that value")
+      Then("the referrer hidden input should contain that value")
       val page = Jsoup.parse(contentAsString(contactResult))
-      page.body().getElementById("referer").attr("value") shouldBe "https://www.example.com/some-service"
+      page.body().getElementById("referrer").attr("value") shouldBe "https://www.example.com/some-service"
     }
 
-    "fallback to n/a if no referer information is available" in new ContactHmrcControllerApplication {
+    "fallback to n/a if no referrer information is available" in new ContactHmrcControllerApplication {
       Given("a GET request")
       mockDeskproConnector(Future.successful(TicketId(12345)))
 
@@ -98,9 +98,9 @@ class ContactHmrcControllerSpec
       When("the unauthenticated Contact HMRC page is requested with a service name")
       val contactResult = controller.indexUnauthenticated(serviceName, None, None)(contactRequest)
 
-      Then("the referer hidden input should be n/a")
+      Then("the referrer hidden input should be n/a")
       val page = Jsoup.parse(contentAsString(contactResult))
-      page.body().getElementById("referer").attr("value") shouldBe "n/a"
+      page.body().getElementById("referrer").attr("value") shouldBe "n/a"
     }
 
     "return expected OK for non-authenticated submit page" in new ContactHmrcControllerApplication {
@@ -112,7 +112,7 @@ class ContactHmrcControllerSpec
         "contact-email" -> "bob@build-it.com",
         "contact-comments" -> "Can We Fix It?",
         "isJavascript" -> "false",
-        "referer" -> "n/a",
+        "referrer" -> "n/a",
         "csrfToken" -> "n/a",
         "service" -> "scp",
         "abFeatures" -> "GetHelpWithThisPageFeature_A",
@@ -145,7 +145,7 @@ class ContactHmrcControllerSpec
           any[Option[String]])(any[HeaderCarrier])
     }
 
-    "send the referer URL to DeskPro" in new ContactHmrcControllerApplication {
+    "send the referrer URL to DeskPro" in new ContactHmrcControllerApplication {
       Given("a POST request containing a valid form")
       mockDeskproConnector(Future.successful(TicketId(12345)))
 
@@ -154,7 +154,7 @@ class ContactHmrcControllerSpec
         "contact-email" -> "bob@build-it.com",
         "contact-comments" -> "Can We Fix It?",
         "isJavascript" -> "false",
-        "referer" -> "https://www.other-gov-domain.gov.uk/path/to/service/page",
+        "referrer" -> "https://www.other-gov-domain.gov.uk/path/to/service/page",
         "csrfToken" -> "n/a",
         "service" -> "scp",
         "abFeatures" -> "GetHelpWithThisPageFeature_A",
@@ -183,7 +183,7 @@ class ContactHmrcControllerSpec
           any[Option[String]])(any[HeaderCarrier])
     }
 
-    "send the referer information to DeskPro with userAction replacing the path if non-empty" in new ContactHmrcControllerApplication {
+    "send the referrer information to DeskPro with userAction replacing the path if non-empty" in new ContactHmrcControllerApplication {
       Given("a POST request containing a valid form")
       mockDeskproConnector(Future.successful(TicketId(12345)))
 
@@ -192,7 +192,7 @@ class ContactHmrcControllerSpec
         "contact-email" -> "bob@build-it.com",
         "contact-comments" -> "Can We Fix It?",
         "isJavascript" -> "false",
-        "referer" -> "https://www.other-gov-domain.gov.uk/path/to/service/page",
+        "referrer" -> "https://www.other-gov-domain.gov.uk/path/to/service/page",
         "csrfToken" -> "n/a",
         "service" -> "scp",
         "abFeatures" -> "GetHelpWithThisPageFeature_A",
@@ -230,7 +230,7 @@ class ContactHmrcControllerSpec
         "contact-email" -> "bob@build-it.com",
         "contact-comments" -> "Can We Fix It?",
         "isJavascript" -> "false",
-        "referer" -> "n/a",
+        "referrer" -> "n/a",
         "csrfToken" -> "n/a",
         "service" -> "scp",
         "recaptcha-v3-response" -> "xx"
@@ -273,7 +273,7 @@ class ContactHmrcControllerSpec
         "contact-email" -> "bob@build-it.com",
         "contact-comments" -> "Can We Fix It?",
         "isJavascript" -> "false",
-        "referer" -> "n/a",
+        "referrer" -> "n/a",
         "csrfToken" -> "n/a",
         "service" -> "scp",
         "abFeatures" -> "GetHelpWithThisPageFeature_A"
@@ -365,7 +365,7 @@ class ContactHmrcControllerSpec
         "contact-email" -> "bob@build-it.com",
         "contact-comments" -> "Can We Fix It?",
         "isJavascript" -> "false",
-        "referer" -> "n/a",
+        "referrer" -> "n/a",
         "csrfToken" -> "n/a",
         "service" -> "scp",
         "abFeatures" -> "GetHelpWithThisPageFeature_A"

--- a/test/controllers/ProblemReportsControllerSpec.scala
+++ b/test/controllers/ProblemReportsControllerSpec.scala
@@ -176,7 +176,7 @@ class ProblemReportsControllerApplication(app: Application) extends MockitoSugar
 
   def generateRequest(javascriptEnabled: Boolean = true, name: String = deskproName, email: String = deskproEmail) = {
 
-    val headers = Seq(("referer", deskproReferrer), ("User-Agent", "iAmAUserAgent")) ++ Seq(("X-Requested-With", "XMLHttpRequest")).filter(_ => javascriptEnabled)
+    val headers = Seq((REFERER, deskproReferrer), ("User-Agent", "iAmAUserAgent")) ++ Seq(("X-Requested-With", "XMLHttpRequest")).filter(_ => javascriptEnabled)
 
     FakeRequest()
       .withHeaders(headers : _*)
@@ -186,7 +186,7 @@ class ProblemReportsControllerApplication(app: Application) extends MockitoSugar
 
   def generateInvalidRequest(javascriptEnabled: Boolean = true) = {
 
-    val headers = Seq(("referer", deskproReferrer), ("User-Agent", "iAmAUserAgent")) ++ Seq(("X-Requested-With", "XMLHttpRequest")).filter(_ => javascriptEnabled)
+    val headers = Seq((REFERER, deskproReferrer), ("User-Agent", "iAmAUserAgent")) ++ Seq(("X-Requested-With", "XMLHttpRequest")).filter(_ => javascriptEnabled)
 
     FakeRequest()
       .withHeaders(headers : _*)

--- a/test/services/DeskproSubmissionSpec.scala
+++ b/test/services/DeskproSubmissionSpec.scala
@@ -7,62 +7,62 @@ package services
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import services.DeskproSubmission.replaceRefererPath
+import services.DeskproSubmission.replaceReferrerPath
 
 class DeskproSubmissionSpec  extends AnyWordSpec with Matchers  {
 
-  "replaceRefererPath" should {
+  "replaceReferrerPath" should {
 
-    "replace the path if different from the referer value" in {
-      val referer = "https://tax.gov.uk/service/accessibility-statement"
+    "replace the path if different from the referrer value" in {
+      val referrer = "https://tax.gov.uk/service/accessibility-statement"
       val userAction = "/service/some-page"
-      val res = replaceRefererPath(referer, Some(userAction))
+      val res = replaceReferrerPath(referrer, Some(userAction))
       res should be ("https://tax.gov.uk" + userAction)
     }
 
 
-    "use user action if referer isn't present" in {
+    "use user action if referrer isn't present" in {
       val userAction = "/service/some-page"
-      val res = replaceRefererPath("", Some(userAction))
+      val res = replaceReferrerPath("", Some(userAction))
       res should be (userAction)
     }
 
-    "use referer if userAction isn't present" in {
-      val referer = "https://tax.gov.uk"
-      val res = replaceRefererPath(referer,None)
-      res should be (referer)
+    "use referrer if userAction isn't present" in {
+      val referrer = "https://tax.gov.uk"
+      val res = replaceReferrerPath(referrer,None)
+      res should be (referrer)
     }
 
     "append a forward slash if userAction is missing one" in {
-      val referer = "https://tax.gov.uk/service/accessibility-statement"
+      val referrer = "https://tax.gov.uk/service/accessibility-statement"
       val userAction = "servicesome-page"
-      val res = replaceRefererPath(referer, Some(userAction))
+      val res = replaceReferrerPath(referrer, Some(userAction))
       res should be ("https://tax.gov.uk" + "/" + userAction)
     }
 
-    "produces just path if referer is a blank string and userAction set" in {
+    "produces just path if referrer is a blank string and userAction set" in {
       val userAction = "/servicesome-page/123"
-      val res = replaceRefererPath("", Some(userAction))
+      val res = replaceReferrerPath("", Some(userAction))
       res should be (userAction)
     }
 
-    "handles invalid uris in referer field" in {
-      val referer = "hello world"
+    "handles invalid uris in referrer field" in {
+      val referrer = "hello world"
       val userAction = "/service/some-page"
-      val res = replaceRefererPath(referer, Some(userAction))
+      val res = replaceReferrerPath(referrer, Some(userAction))
       res should be (userAction)
     }
 
     "doesn't replace path if userAction is a empty string" in {
-      val referer = "https://tax.gov.uk/service/accessibility-statement"
-      val res = replaceRefererPath(referer, Some(""))
-      res should be (referer)
+      val referrer = "https://tax.gov.uk/service/accessibility-statement"
+      val res = replaceReferrerPath(referrer, Some(""))
+      res should be (referrer)
     }
 
     "doesn't replace path if userAction is just whitespace" in {
-      val referer = "https://tax.gov.uk/service/accessibility-statement"
-      val res = replaceRefererPath(referer, Some("         "))
-      res should be (referer)
+      val referrer = "https://tax.gov.uk/service/accessibility-statement"
+      val res = replaceReferrerPath(referrer, Some("         "))
+      res should be (referrer)
     }
   }
 


### PR DESCRIPTION
As per PLATUI-512 to resolve GLSD-2102, this provides a mechanism for services outside the www.tax.service.gov.uk domain to communicate the referring URL to contact-frontend without relying on the HTTP Referer header being forwarded correctly by browsers in all circumstances.

There is a related SCP ticket BAS-12148 to provide the referrerUrl.