### PR TITLE
removed CSRF bypass because no allowlist header present

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -48,12 +48,6 @@ play.http.errorHandler = "config.ContactFrontendErrorHandler"
 
 play.http.filters = "config.ContactFrontendFilters"
 
-
-play.filters.csrf.header.bypassHeaders {
-  X-Requested-With = "*"
-  Csrf-Token = "nocheck"
-}
-
 play.http.router = prod.Routes
 
 play.i18n.langs = ["en", "cy"]


### PR DESCRIPTION
The CSRF bypass header is being used without an allowlist. Have removed it in this commit to close this vulnerability.
https://jira.tools.tax.service.gov.uk/browse/PSEC-1051