### PR TITLE
NOJIRA - bring in core fix for HmrcNewTabLinkHelper trailing space

### DIFF
--- a/app/views/ContactHmrcPage.scala.html
+++ b/app/views/ContactHmrcPage.scala.html
@@ -51,7 +51,7 @@
         @govukErrorSummary(ErrorSummary().withFormErrorsAsText(contactForm))
     }
     @h1(content = Text(messages("contact.heading")))
-    @p(content = HtmlContent(messages("contact.form.para1") + " " + contactHmrcLink.trim + messages("common.fullstop")))
+    @p(content = HtmlContent(messages("contact.form.para1") + " " + contactHmrcLink + messages("common.fullstop")))
     @p(content = Text(messages("contact.form.para2")))
     @h2(content = Text(messages("contact.form.heading2")))
     @p(content = Text(messages("contact.form.para3")))

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,7 +14,7 @@ object AppDependencies {
     "uk.gov.hmrc"              %% "url-builder"                % "3.5.0-play-28",
     "uk.gov.hmrc"              %% "auth-client"                % "5.6.0-play-28",
     "org.apache.httpcomponents" % "httpclient"                 % "4.4.1",
-    "uk.gov.hmrc"              %% "play-frontend-hmrc"         % "3.13.0-play-28"
+    "uk.gov.hmrc"              %% "play-frontend-hmrc"         % "3.14.0-play-28"
   )
 
   private def test(scope: String) = Seq(


### PR DESCRIPTION
* bump play-frontend-hmrc version
* remove `.trim` workaround