### PR TITLE
Fix intermittent test failure in contact-frontend build

### DIFF
--- a/test/acceptance/specs/ReportProblemPartialSpec.scala
+++ b/test/acceptance/specs/ReportProblemPartialSpec.scala
@@ -19,8 +19,9 @@ package acceptance.specs
 import acceptance.pages.{TestOnlyReportProblemPartialPage, TestOnlyReportProblemPartialPageAjax}
 import acceptance.pages.TestOnlyReportProblemPartialPage._
 import acceptance.specs.tags.UiTests
+import acceptance.support.IntegrationPatience
 
-class ReportProblemPartialSpec extends BaseSpec {
+class ReportProblemPartialSpec extends BaseSpec with IntegrationPatience {
 
   info("UI tests for partial `Is this page not working properly` embedded form")
 

--- a/test/acceptance/support/IntegrationPatience.scala
+++ b/test/acceptance/support/IntegrationPatience.scala
@@ -1,0 +1,11 @@
+package acceptance.support
+
+import org.scalatest.concurrent.Eventually.PatienceConfig
+import org.scalatest.concurrent.Futures.scaled
+import org.scalatest.time.{Seconds, Span}
+
+trait IntegrationPatience {
+  protected val timeoutInSeconds: Int                        = 2
+  implicit val eventuallyWithTimeoutOverride: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(timeoutInSeconds, Seconds)))
+}


### PR DESCRIPTION
I initially tried to replicate the Jenkins issue locally but with no success, I kept getting different errors and sometimes errors that didn't make sense at all.

I decided to update the eventual patience config by setting a higher timeout value compared to the default value of 150 milliseconds. This seemed to give consistent test results in Jenkins.