### PR TITLE
PLATUI-1776 bump a11y linter and configure concise output

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val microservice = Project(appName, file("."))
 lazy val unitTestSettings =
   inConfig(Test)(Defaults.testTasks) ++
     Seq(
-      testOptions in Test := Seq(
+      Test / testOptions := Seq(
         Tests.Filters(
           Seq(
             _ startsWith "connectors",
@@ -63,7 +63,7 @@ lazy val acceptanceTestSettings =
     Seq(
       // The following is needed to preserve the -Dbrowser option to the HMRC webdriver factory library
       fork in AcceptanceTest := false,
-      (testOptions in AcceptanceTest) := Seq(Tests.Filter(_ startsWith "acceptance")),
+      AcceptanceTest / testOptions := Seq(Tests.Filter(_ startsWith "acceptance")),
       AcceptanceTest / run / javaOptions ++= Seq(
         "-Dconfig.resource=test.application.conf",
         "-Dlogger.resource=logback-test.xml"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -174,3 +174,7 @@ akka.http.parsing.max-uri-length = 16k
 
 # This flag is used to enable the capture of the "referer" header if the referrerUrl is not passed via the query string
 useRefererHeader = true
+
+sbt-accessibility-linter {
+  output-format = "concise"
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,4 +15,4 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-accessibility-linter" % "0.22.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-accessibility-linter" % "0.25.0")


### PR DESCRIPTION
* bump `sbt-accessibility-linter` to 0.25.0 to enable concise mode
* configure concise output format
* fix a couple of sbt deprecation warnings