### PR TITLE
PLATUI-2665 update to Play 3.0

### DIFF
--- a/app/connectors/deskpro/domain/DeskProDomain.scala
+++ b/app/connectors/deskpro/domain/DeskProDomain.scala
@@ -17,7 +17,7 @@
 package connectors.deskpro.domain
 
 import play.api.Logging
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.Request
 import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
@@ -40,7 +40,7 @@ case class Ticket private (
 
 object Ticket extends FieldTransformer with Logging {
 
-  implicit val formats = Json.format[Ticket]
+  implicit val formats: OFormat[Ticket] = Json.format[Ticket]
 
   def create(
     name: String,
@@ -76,7 +76,7 @@ object Ticket extends FieldTransformer with Logging {
 }
 
 object TicketId {
-  implicit val formats = Json.format[TicketId]
+  implicit val formats: OFormat[TicketId] = Json.format[TicketId]
 }
 
 case class TicketId(ticket_id: Int)
@@ -99,7 +99,7 @@ case class Feedback(
 
 object Feedback extends FieldTransformer {
 
-  implicit val formats = Json.format[Feedback]
+  implicit val formats: OFormat[Feedback] = Json.format[Feedback]
 
   def create(
     name: String,

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
-    scalaVersion := "2.13.8",
+    scalaVersion := "2.13.12",
     majorVersion := 4,
     libraryDependencies ++= AppDependencies.dependencies(testPhases = Seq("test", "it"))
   )
@@ -26,15 +26,11 @@ lazy val microservice = Project(appName, file("."))
       "uk.gov.hmrc.govukfrontend.views.html.components._",
       "uk.gov.hmrc.hmrcfrontend.views.html.components._"
     ),
-    // ***************
-    // Use the silencer plugin to suppress warnings from unused imports in compiled twirl templates
-    scalacOptions += "-P:silencer:pathFilters=views;routes",
-    libraryDependencies ++= Seq(
-      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.8" cross CrossVersion.full),
-      "com.github.ghik" % "silencer-lib" % "1.7.8" % Provided cross CrossVersion.full
-    ),
-    // ***************
     A11yTest / unmanagedSourceDirectories += (baseDirectory.value / "test" / "a11y")
+  )
+  .settings(
+    scalacOptions += "-Wconf:src=routes/.*:s",
+    scalacOptions += "-Wconf:src=views/.*:s"
   )
 
 lazy val unitTestSettings =

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,2 +1,1 @@
 ->         /contact              contact.Routes
-GET        /admin/metrics        @com.kenshoo.play.metrics.MetricsController.metrics

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -99,7 +99,7 @@ tracking-consent-frontend {
   gtm.container = "b"
 }
 
-akka.http.parsing.max-uri-length = 16k
+pekko.http.parsing.max-uri-length = 16k
 
 # Feature flags
 # This flag is used to switch to use deskpro-ticket-queue (default backend is hmrc-deskpro)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,22 +7,23 @@ object AppDependencies {
     compile ++ testDependencies
   }
 
-  private val bootstrapPlayVersion = "7.22.0"
+  private val bootstrapFrontendVersion = "8.1.0"
+  private val playFrontendHmrcVersion  = "8.0.0"
+  private val playVersion              = "play-30"
 
   private val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "7.29.0-play-28"
+    "uk.gov.hmrc" %% s"bootstrap-frontend-$playVersion" % bootstrapFrontendVersion,
+    "uk.gov.hmrc" %% s"play-frontend-hmrc-$playVersion" % playFrontendHmrcVersion
   )
 
   private def test(scope: String) = Seq(
-    "uk.gov.hmrc"           %% "bootstrap-test-play-28"  % bootstrapPlayVersion % scope,
-    "uk.gov.hmrc"           %% "domain"                  % "8.3.0-play-28"      % scope,
-    "uk.gov.hmrc"           %% "webdriver-factory"       % "0.41.0"             % scope,
-    "org.scalatestplus"     %% "scalatestplus-mockito"   % "1.0.0-M2"           % scope,
-    "org.scalatestplus"     %% "selenium-4-2"            % "3.2.13.0"           % scope,
-    "org.mockito"           %% "mockito-scala-scalatest" % "1.16.37"            % scope,
-    "org.jsoup"              % "jsoup"                   % "1.11.3"             % scope,
-    "com.github.tomakehurst" % "wiremock"                % "1.58"               % scope,
-    "com.github.tomakehurst" % "wiremock-jre8"           % "2.27.2"             % scope
+    "uk.gov.hmrc"           %% s"bootstrap-test-$playVersion" % bootstrapFrontendVersion % scope,
+    "uk.gov.hmrc"           %% "webdriver-factory"            % "0.46.0"                 % scope,
+    "org.scalatestplus"     %% "scalatestplus-mockito"        % "1.0.0-M2"               % scope,
+    "org.scalatestplus"     %% "selenium-4-2"                 % "3.2.13.0"               % scope,
+    "org.mockito"           %% "mockito-scala-scalatest"      % "1.16.37"                % scope,
+    "org.jsoup"              % "jsoup"                        % "1.11.3"                 % scope,
+    "com.github.tomakehurst" % "wiremock"                     % "1.58"                   % scope,
+    "com.github.tomakehurst" % "wiremock-jre8"                % "2.27.2"                 % scope
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,14 +5,9 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.15.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
-
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
-
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-accessibility-linter" % "0.36.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-accessibility-linter" % "0.36.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"           % "3.15.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"       % "2.4.0")
+addSbtPlugin("org.playframework" % "sbt-plugin"               % "3.0.0")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"             % "2.4.0")
+addSbtPlugin("com.typesafe.sbt"  % "sbt-gzip"                 % "1.0.2")

--- a/test/connectors/deskpro/domain/FieldTransformerSpec.scala
+++ b/test/connectors/deskpro/domain/FieldTransformerSpec.scala
@@ -23,7 +23,6 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
-import uk.gov.hmrc.domain._
 import uk.gov.hmrc.http.SessionId
 import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
 
@@ -91,7 +90,7 @@ class FieldTransformerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
         "utr"    -> "sa",
         "ctUtr"  -> "ct",
         "vrn"    -> "vrn1",
-        "empRef" -> EmpRef("officeNum", "officeRef").value
+        "empRef" -> "officeNum/officeRef"
       )
     }
 
@@ -100,7 +99,7 @@ class FieldTransformerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
         "utr"                          -> "sa",
         "ctUtr"                        -> "ct",
         "vrn"                          -> "vrn2",
-        "empRef"                       -> EmpRef("officeNum", "officeRef").value,
+        "empRef"                       -> "officeNum/officeRef",
         "HMCE-VAT-AGNT/AgentRefNo"     -> "Foo",
         "IR-CT-AGENT/IRAgentReference" -> "Bar"
       )

--- a/test/controllers/ContactHmrcControllerSpec.scala
+++ b/test/controllers/ContactHmrcControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer._
 import config.CFConfig
 import connectors.deskpro.DeskproTicketQueueConnector
 import connectors.deskpro.domain.{TicketConstants, TicketId}
@@ -38,7 +37,7 @@ import play.api.i18n.{Lang, Messages, MessagesApi}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Request
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{contentAsJson, contentAsString, redirectLocation, _}
+import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.tools.Stubs
@@ -437,9 +436,9 @@ class ContactHmrcControllerSpec
 
     val configuration = app.configuration
 
-    implicit val appConfig        = new CFConfig(configuration)
-    implicit val executionContext = ExecutionContext.Implicits.global
-    implicit val messages         = app.injector.instanceOf[MessagesApi]
+    implicit val appConfig: CFConfig                = new CFConfig(configuration)
+    implicit val executionContext: ExecutionContext = ExecutionContext.Implicits.global
+    implicit val messages: MessagesApi              = app.injector.instanceOf[MessagesApi]
 
     val ticketQueueConnector                     = mock[DeskproTicketQueueConnector]
     val enrolmentsConnector: EnrolmentsConnector = mock[EnrolmentsConnector]

--- a/test/controllers/SurveyControllerSpec.scala
+++ b/test/controllers/SurveyControllerSpec.scala
@@ -25,7 +25,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.data.FormError
-import play.api.i18n.MessagesApi
+import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.{FakeHeaders, FakeRequest}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
@@ -73,7 +73,7 @@ class SurveyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
     }
 
     "produce an audit result for a valid form" in new TestScope {
-      implicit val request = FakeRequest(
+      implicit val request: FakeRequest[_] = FakeRequest(
         "POST",
         "/",
         FakeHeaders(),
@@ -103,7 +103,7 @@ class SurveyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
     }
 
     "produce errors for an invalid form" in new TestScope {
-      implicit val request = FakeRequest(
+      implicit val request: FakeRequest[_] = FakeRequest(
         "POST",
         "/",
         FakeHeaders(),
@@ -127,8 +127,9 @@ class SurveyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
     val serviceId = "abcdefg"
     val request   = FakeRequest("POST", "/")
 
-    implicit val messages = messagesApi.preferred(request)
-    val result            = controller.submit(ticketId, serviceId)(request)
+    implicit val messages: Messages = messagesApi.preferred(request)
+
+    val result = controller.submit(ticketId, serviceId)(request)
 
     status(result) should be(400)
 
@@ -156,8 +157,9 @@ class SurveyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
     )
     val request   = FakeRequest("POST", "/").withFormUrlEncodedBody(fields.toSeq: _*)
 
-    implicit val messages = messagesApi.preferred(request)
-    val result            = controller.submit(ticketId, serviceId)(request)
+    implicit val messages: Messages = messagesApi.preferred(request)
+
+    val result = controller.submit(ticketId, serviceId)(request)
 
     status(result) should be(400)
 

--- a/test/support/AcceptanceTestServer.scala
+++ b/test/support/AcceptanceTestServer.scala
@@ -34,7 +34,6 @@ trait AcceptanceTestServer extends TestSuiteMixin with GuiceFakeApplicationFacto
         "play.http.router" -> "testOnlyDoNotUseInAppConf.Routes"
       )
     )
-    .disable[com.kenshoo.play.metrics.PlayModule]
     .build()
 
   private def runSuiteWithTestServer(testName: Option[String], args: Args): Status = {


### PR DESCRIPTION
* upgrade bootstrap and frontend libraries to Play 3.0 versions
* upgrade various other dependencies to latest
* remove redundant kenshoo metrics stuff
* remove dependency on hmrc/domain which was only used in tests, and is not available for Play 3.0 yet
* replace silencer plugin with native scalac config
* rename akka->pekko and update integration spec to more closely reflect the config it's testing
* add type annotations for various implicits, to silence warnings