### PR TITLE
Update DeskProDomain.scala

### DIFF
--- a/app/connectors/deskpro/domain/DeskProDomain.scala
+++ b/app/connectors/deskpro/domain/DeskProDomain.scala
@@ -70,7 +70,6 @@ object Ticket extends FieldTransformer with Logging {
       service,
       userAction
     )
-    logger.info(s"Creating ticket $ticket")
     ticket
   }
 }


### PR DESCRIPTION
Removing possible broken step from future platui's path where we don't log info messages in prod but if we turned it on then we'd start logging PII

Checked in config and kibana and nothing logged