### PR TITLE
PLATUI-3172 bump play-frontend-hmrc and remove url param

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   }
 
   private val bootstrapFrontendVersion = "9.0.0"
-  private val playFrontendHmrcVersion  = "10.4.0"
+  private val playFrontendHmrcVersion  = "10.6.0"
   private val playVersion              = "play-30"
 
   private val compile = Seq(

--- a/test/views/FeedbackPageSpec.scala
+++ b/test/views/FeedbackPageSpec.scala
@@ -483,7 +483,7 @@ class FeedbackPageSpec
         action
       )
 
-      val links = contentWithService.select("a[href=/contact/report-technical-problem?newTab=true&service=foo]")
+      val links = contentWithService.select("a[href=/contact/report-technical-problem?service=foo]")
       links              should have size 1
       links.first.text shouldBe "Is this page not working properly? (opens in new tab)"
     }


### PR DESCRIPTION
# Purpose of PR

- Bump play-frontend-hmrc to latest (10.6.0)
- Remove unused url parameter from report technical problem test