### PR TITLE
example refactor that passes implicit

### DIFF
--- a/test/controllers/AccessibilityControllerSpec.scala
+++ b/test/controllers/AccessibilityControllerSpec.scala
@@ -16,13 +16,13 @@
 
 package controllers
 
-import config.*
 import connectors.deskpro.DeskproTicketQueueConnector
 import connectors.deskpro.domain.{TicketConstants, TicketId}
 import connectors.enrolments.EnrolmentsConnector
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.*
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
@@ -32,31 +32,63 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.Request
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
-import play.api.Application
+import play.api.{Application, inject}
+import play.api.inject.*
 import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.bootstrap.tools.Stubs
-import util.RefererHeaderRetriever
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.jdk.CollectionConverters.*
 
-class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+class AccessibilityControllerSpec extends AnyWordSpec with Matchers with MockitoSugar with BeforeAndAfterEach with GuiceOneAppPerSuite {
+
+  private val ticketQueueConnector = mock[DeskproTicketQueueConnector]
+  private val enrolmentsConnector  = mock[EnrolmentsConnector]
+  when(enrolmentsConnector.maybeAuthenticatedUserEnrolments()(using any())(using any()))
+    .thenReturn(Future.successful(None))
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(ticketQueueConnector)
+  }
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
+      .bindings(
+        bind[DeskproTicketQueueConnector].toInstance(ticketQueueConnector),
+        bind[EnrolmentsConnector].toInstance(enrolmentsConnector)
+      )
       .configure("metrics.jvm" -> false, "metrics.enabled" -> false, "useRefererHeader" -> true)
       .build()
 
-  given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("en")))
+  private def generateRequest(desc: String, formName: String, email: String, isJavascript: Boolean, referrer: String) = {
+    val fields = Map(
+      "problemDescription" -> desc,
+      "name" -> formName,
+      "email" -> email,
+      "csrfToken" -> "token",
+      "isJavascript" -> isJavascript.toString,
+      "csrfToken" -> "a-csrf-token",
+      "referrer" -> referrer,
+      "service" -> "unit-test",
+      "userAction" -> "/test/url/action"
+    )
+
+    FakeRequest("POST", "/")
+      .withHeaders((REFERER, referrer))
+      .withFormUrlEncodedBody(fields.toSeq: _*)
+  }
 
   // RFC 5321: https://tools.ietf.org/html/rfc5321
   // Maximum domain name length: https://www.nic.ad.jp/timeline/en/20th/appendix1.html#:~:text=Each%20element%20of%20a%20domain,a%20maximum%20of%20253%20characters.
-  val tooLongEmail = ("x" * 64) + "@" + ("x" * 63) + "." + ("x" * 63) + "." + ("x" * 63) + "." + ("x" * 57) + ".com"
+  private val tooLongEmail = ("x" * 64) + "@" + ("x" * 63) + "." + ("x" * 63) + "." + ("x" * 63) + "." + ("x" * 57) + ".com"
 
   "Reporting an accessibility problem" should {
+    val controller = app.injector.instanceOf[AccessibilityController]
+    given Messages = app.injector.instanceOf[MessagesApi].preferred(Seq(Lang("en")))
+    given HeaderCarrier = any[HeaderCarrier]
 
-    "return 200 and a valid html page for a request with optional referrerUrl" in new TestScope {
+    "return 200 and a valid html page for a request with optional referrerUrl" in {
 
       val request = FakeRequest().withHeaders((REFERER, "referrer.from.header"))
       val result  = controller.index(
@@ -74,7 +106,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       document.getElementsByAttributeValue("name", "referrer").first().`val`()   shouldBe "some.referrer.url"
     }
 
-    "return 200 and a valid html page for a request when no referrerUrl and referer in header" in new TestScope {
+    "return 200 and a valid html page for a request when no referrerUrl and referer in header" in {
 
       val request = FakeRequest().withHeaders((REFERER, "referrer.from.header"))
       val result  = controller.index(
@@ -88,7 +120,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       document.getElementsByAttributeValue("name", "referrer").first().`val`() shouldBe "referrer.from.header"
     }
 
-    "return 200 and a valid html page for a request when no referrerUrl and no referer in header" in new TestScope {
+    "return 200 and a valid html page for a request when no referrerUrl and no referer in header" in {
 
       val request = FakeRequest()
       val result  = controller.index(
@@ -102,7 +134,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       document.getElementsByAttributeValue("name", "referrer").first().`val`() shouldBe "n/a"
     }
 
-    "display errors when form isn't filled out at all" in new TestScope {
+    "display errors when form isn't filled out at all" in {
 
       val request = generateRequest(desc = "", formName = "", email = "", isJavascript = false, referrer = "/somepage")
       val result  = controller.submit(None, None)(request)
@@ -119,7 +151,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       errors.exists(_.text().contains(Messages("accessibility.email.error.required")))   shouldBe true
     }
 
-    "display error messages when message size exceeds limit" in new TestScope {
+    "display error messages when message size exceeds limit" in {
       val msg2500 = "x" * 2500
 
       val request = generateRequest(
@@ -141,7 +173,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       errors.exists(_.text().contains(Messages("accessibility.problem.error.length"))) shouldBe true
     }
 
-    "display error messages when email is invalid" in new TestScope {
+    "display error messages when email is invalid" in {
       val badEmail = "firstname'email.gov."
 
       val request = generateRequest(
@@ -163,7 +195,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       errors.exists(_.text().contains(Messages("accessibility.email.error.invalid"))) shouldBe true
     }
 
-    "display error messages when email is too long" in new TestScope {
+    "display error messages when email is too long" in {
       val request = generateRequest(
         desc = "valid form message",
         formName = "firstname",
@@ -181,7 +213,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       errors.exists(_.text().contains(Messages("accessibility.email.error.length"))) shouldBe true
     }
 
-    "display error messages when name is too long" in new TestScope {
+    "display error messages when name is too long" in {
       val longName = "x" * 256
 
       val request = generateRequest(
@@ -201,7 +233,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       errors.exists(_.text().contains(Messages("accessibility.name.error.length"))) shouldBe true
     }
 
-    "redirect to thankyou page when completed" in new TestScope {
+    "redirect to thankyou page when completed" in {
       when(
         ticketQueueConnector.createDeskProTicket(
           name = any[String],
@@ -230,7 +262,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       header(LOCATION, result) should be(Some("/contact/accessibility/thanks"))
     }
 
-    "return error page if the Deskpro ticket creation fails" in new TestScope {
+    "return error page if the Deskpro ticket creation fails" in {
       when(
         ticketQueueConnector.createDeskProTicket(
           name = any[String],
@@ -243,7 +275,7 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
           any[Option[String]],
           any[Option[String]],
           any[TicketConstants]
-        )
+        )(using any[HeaderCarrier])
       ).thenReturn(Future.failed(new Exception("failed")))
 
       val request = generateRequest(
@@ -261,53 +293,6 @@ class AccessibilityControllerSpec extends AnyWordSpec with Matchers with GuiceOn
       val document = Jsoup.parse(contentAsString(result))
       document.text() should include("Sorry, there is a problem with the service")
       document.text() should include("Try again later.")
-    }
-  }
-
-  class TestScope extends MockitoSugar {
-
-    val ticketQueueConnector: DeskproTicketQueueConnector = mock[DeskproTicketQueueConnector]
-
-    val enrolmentsConnector: EnrolmentsConnector = mock[EnrolmentsConnector]
-    when(enrolmentsConnector.maybeAuthenticatedUserEnrolments()(using any())(using any()))
-      .thenReturn(Future.successful(None))
-
-    given AppConfig        = new CFConfig(app.configuration)
-    given ExecutionContext = ExecutionContext.global
-    given HeaderCarrier    = any[HeaderCarrier]
-
-    val messages                                  = app.injector.instanceOf[MessagesApi]
-    val playFrontendAccessibilityPage             = app.injector.instanceOf[views.html.AccessibilityProblemPage]
-    val playFrontendAccessibilityConfirmationPage =
-      app.injector.instanceOf[views.html.AccessibilityProblemConfirmationPage]
-    val errorPage                                 = app.injector.instanceOf[views.html.InternalErrorPage]
-
-    val controller = new AccessibilityController(
-      ticketQueueConnector,
-      enrolmentsConnector,
-      Stubs.stubMessagesControllerComponents(messagesApi = messages),
-      playFrontendAccessibilityPage,
-      playFrontendAccessibilityConfirmationPage,
-      errorPage,
-      new RefererHeaderRetriever
-    )
-
-    def generateRequest(desc: String, formName: String, email: String, isJavascript: Boolean, referrer: String) = {
-      val fields = Map(
-        "problemDescription" -> desc,
-        "name"               -> formName,
-        "email"              -> email,
-        "csrfToken"          -> "token",
-        "isJavascript"       -> isJavascript.toString,
-        "csrfToken"          -> "a-csrf-token",
-        "referrer"           -> referrer,
-        "service"            -> "unit-test",
-        "userAction"         -> "/test/url/action"
-      )
-
-      FakeRequest("POST", "/")
-        .withHeaders((REFERER, referrer))
-        .withFormUrlEncodedBody(fields.toSeq: _*)
     }
   }
 


### PR DESCRIPTION
read comment and my brain went "that's interesting" so had a go myself

I think the issue was missing implicit header carrier that was needed in some scenario

I think mockito didn't support it for a while and that's why some people were going to scalamock

however [seems](https://stackoverflow.com/questions/79522418/mocking-method-with-given-parameter-with-scala-3) to now be supported: 

> With Scala 3.6.4 and ScalaTest+Mockito 3.2.19.0, the following works:
> ```
> when(myClass.foo(any[Int]())(using any[String]())).thenReturn(IO.unit)
> ```