### PR TITLE
NOJIRA example of propagating service nav usage

### DIFF
--- a/app/controllers/AccessibilityController.scala
+++ b/app/controllers/AccessibilityController.scala
@@ -29,6 +29,7 @@ import play.api.mvc.*
 import play.filters.csrf.CSRF
 import play.twirl.api.Html
 import services.DeskproSubmission
+import uk.gov.hmrc.hmrcfrontend.config.ServiceNavCanBeControlledByRequestAttr.UseServiceNav
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import util.{DeskproEmailValidator, NameValidator, RefererHeaderRetriever}
 import views.html.{AccessibilityProblemConfirmationPage, AccessibilityProblemPage, InternalErrorPage}
@@ -109,7 +110,7 @@ class AccessibilityController @Inject() (
     referrerUrl: Option[ReferrerUrl]
   ): Action[AnyContent] =
     Action.async { request =>
-      given Request[AnyContent] = request
+      given Request[AnyContent] = request.addAttr(UseServiceNav, true)
       Future.successful {
         val submit    = routes.AccessibilityController.submit(service, userAction)
         val referrer  = referrerUrl orElse headerRetriever.refererFromHeaders()
@@ -121,7 +122,7 @@ class AccessibilityController @Inject() (
 
   def submit(service: Option[String], userAction: Option[String]): Action[AnyContent] =
     Action.async { request =>
-      given Request[AnyContent] = request
+      given Request[AnyContent] = request.addAttr(UseServiceNav, true)
       AccessibilityFormBind.form
         .bindFromRequest()
         .fold(
@@ -146,7 +147,7 @@ class AccessibilityController @Inject() (
     }
 
   def thanks(): Action[AnyContent] = Action.async { request =>
-    given Request[AnyContent] = request
+    given Request[AnyContent] = request.addAttr(UseServiceNav, true)
     Future.successful(Ok(accessibilityProblemConfirmationPage()))
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -33,6 +33,8 @@ include "frontend.conf"
 
 appName = "contact-frontend"
 
+play.modules.disabled += "uk.gov.hmrc.hmrcfrontend.config.DefaultServiceNavConfigModule"
+
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapFrontendVersion = "10.5.0"
-  private val playFrontendHmrcVersion  = "12.31.0"
+  private val playFrontendHmrcVersion  = "12.32.0-SNAPSHOT"
   private val playVersion              = "play-30"
 
   val compile: Seq[ModuleID] = Seq(


### PR DESCRIPTION
example of service being able to override how service nav usage gets determined - for example by matching against some identifier from the request to a list from config

where service nav feature flag has been turned in the play-frontend-hmrc snapshot into a trait so that it can be overridden

https://github.com/hmrc/play-frontend-hmrc/pull/397
https://github.com/hmrc/help-frontend/pull/172

if people needed to base decision off something else, then instead they could use the one that bases decision off present of request attribute, and then they "just" need to add that request attribute in during the chain

for example, if someone was looking up say user answers or address lookup journey or something, then wherever they reify that from request, maybe in an action helper thing - where they pass the wrapped enriched request they can replace the request with request

like
```
request.addAttr(UseServiceNav, session.useServiceNav)
```

(replacing session.useServiceNav with however they want to resolve it)